### PR TITLE
Retain pre-existing remote build cache config

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-remote-build-caching.gradle
@@ -11,11 +11,21 @@ settingsEvaluated { settings ->
         local {
             enabled = false
         }
-        remote(HttpBuildCache) {
+        (remote ?: remote(HttpBuildCache)).with {
             enabled = true
             push = false
-            if (remoteBuildCacheUrl) {
-                url = withPathTrailingSlash(new URI(remoteBuildCacheUrl))
+            def uri = remoteBuildCacheUrl
+                ? withPathTrailingSlash(new URI(remoteBuildCacheUrl))
+                : null
+            if (uri && delegate instanceof HttpBuildCache) {
+                url = uri
+            } else if (uri && delegate.class.name.startsWith('com.gradle.develocity')) {
+                path = uri.path
+            } else {
+                logger.warn("""
+                    Couldn't set build cache path automatically for remote of type '${delegate.class.name}'.
+                    Please ensure the path set on the 2nd build is the same as the 1st build.
+                """.stripIndent())
             }
         }
     }

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
-- [NEW] TBD
+- [NEW] Support remote build cache authentication and the [Develocity connector](https://docs.gradle.com/develocity/gradle-plugin/current/#using_the_develocity_connector)


### PR DESCRIPTION
Retain pre-existing remote cache configuration when setting the cache path, by never replacing an existing cache. Also support using the Develocity connector and warn in case the build has a custom cache type, for which the script cannot set the cache path.

Closes #507