### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/.github/actions/gradle/README.md
+++ b/.github/actions/gradle/README.md
@@ -14,25 +14,25 @@ Create a GitHub Actions workflow with the following steps:
 ```yaml
 steps:
   # Download the latest version of the build validation scripts
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
   # Run experiment 1
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
     with:
       gitRepo: <PROJECT_GIT_URL>
       gitBranch: <PROJECT_BRANCH>
       tasks: <PROJECT_BUILD_TASK>
       ...
   # Run experiment 2
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-2@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-2@actions-stable
     with:
       gitRepo: <PROJECT_GIT_URL>
       gitBranch: <PROJECT_BRANCH>
       tasks: <PROJECT_BUILD_TASK>
       ...
   # Run experiment 3
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
     with:
       gitRepo: <PROJECT_GIT_URL>
       gitBranch: <PROJECT_BRANCH>
@@ -56,11 +56,11 @@ steps:
     with:
       path: project-to-validate # Check out the project to a directory named 'project-to-validate'
   - name: Download latest version of the validation scripts
-    uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
+    uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
   - name: Run experiment 3
-    uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
+    uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
     with:
       gitRepo: "file://$GITHUB_WORKSPACE/project-to-validate" # Use 'project-to-validate' for the experiment
       tasks: <PROJECT_BUILD_TASK>
@@ -80,7 +80,7 @@ Create a GitHub Actions workflow with the following steps:
 ```yaml
 steps:
   # Run configuration cache experiment
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-config-cache@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-config-cache@actions-stable
     with:
       tasks: "build"
       args: "-Pfoo=bar"

--- a/.github/actions/gradle/download/action.yml
+++ b/.github/actions/gradle/download/action.yml
@@ -23,9 +23,9 @@ runs:
           curlOpts+=(--header 'Authorization: Bearer ${{ inputs.token }}')
         fi
 
-        releaseUrl="https://api.github.com/repos/gradle/gradle-enterprise-build-validation-scripts/releases/latest"
+        releaseUrl="https://api.github.com/repos/gradle/develocity-build-validation-scripts/releases/latest"
         if [ "${{ inputs.downloadDevelopmentRelease }}" == "true" ]; then
-          releaseUrl="https://api.github.com/repos/gradle/gradle-enterprise-build-validation-scripts/releases/tags/development-latest"
+          releaseUrl="https://api.github.com/repos/gradle/develocity-build-validation-scripts/releases/tags/development-latest"
         fi
 
         # Get the download url of the latest development or released version

--- a/.github/actions/maven/README.md
+++ b/.github/actions/maven/README.md
@@ -14,18 +14,18 @@ Create a GitHub Actions workflow with the following steps:
 ```yaml
 steps:
   # Download the latest version of the build validation scripts
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/maven/download@actions-stable
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
   # Run experiment 1
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable
     with:
       gitRepo: <PROJECT_GIT_URL>
       gitBranch: <PROJECT_BRANCH>
       goals: <PROJECT_BUILD_GOAL>
       ...
   # Run experiment 2
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
     with:
       gitRepo: <PROJECT_GIT_URL>
       gitBranch: <PROJECT_BRANCH>
@@ -48,11 +48,11 @@ steps:
     uses: actions/checkout@v4
     with:
       path: project-to-validate # Check out the project to a directory named 'project-to-validate'
-  - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
+  - uses: gradle/develocity-build-validation-scripts/.github/actions/maven/download@actions-stable
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
   - name: Run experiment 2
-    uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
+    uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
     with:
       gitRepo: "file://$GITHUB_WORKSPACE/project-to-validate" # Use 'project-to-validate' for the experiment
       goals: <PROJECT_BUILD_GOAL>

--- a/.github/actions/maven/download/action.yml
+++ b/.github/actions/maven/download/action.yml
@@ -23,9 +23,9 @@ runs:
           curlOpts+=(--header 'Authorization: Bearer ${{ inputs.token }}')
         fi
 
-        releaseUrl="https://api.github.com/repos/gradle/gradle-enterprise-build-validation-scripts/releases/latest"
+        releaseUrl="https://api.github.com/repos/gradle/develocity-build-validation-scripts/releases/latest"
         if [ "${{ inputs.downloadDevelopmentRelease }}" == "true" ]; then
-          releaseUrl="https://api.github.com/repos/gradle/gradle-enterprise-build-validation-scripts/releases/tags/development-latest"
+          releaseUrl="https://api.github.com/repos/gradle/develocity-build-validation-scripts/releases/tags/development-latest"
         fi
 
         # Get the download url of the latest development or released version

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   combine-dependabot-prs:
-    if: github.repository == 'gradle/gradle-enterprise-build-validation-scripts'
+    if: github.repository == 'gradle/develocity-build-validation-scripts'
     runs-on: ubuntu-latest
     steps:
       - name: combine-dependabot-prs

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -60,9 +60,9 @@ jobs:
           distribution: ${{ matrix.os == 'macos-14' && 'zulu' || 'temurin' }} # No Temurin JDK 8 distribution for aarch64
       - name: Download and extract build validation Scripts
         run: |
-          curl -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/development-latest/develocity-gradle-build-validation-dev.zip
+          curl -L -O https://github.com/gradle/develocity-build-validation-scripts/releases/download/development-latest/develocity-gradle-build-validation-dev.zip
           unzip -o develocity-gradle-build-validation-*.zip
-          curl -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/development-latest/develocity-maven-build-validation-dev.zip
+          curl -L -O https://github.com/gradle/develocity-build-validation-scripts/releases/download/development-latest/develocity-maven-build-validation-dev.zip
           unzip -o develocity-maven-build-validation-*.zip
       - name: Run Gradle Experiment 01
         working-directory: develocity-gradle-build-validation

--- a/Gradle.md
+++ b/Gradle.md
@@ -26,7 +26,7 @@ The build validation scripts are compatible with a large range of Gradle version
 Use the following command to download and unpack the build validation scripts for Gradle to the current directory:
 
 ```bash
-curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v2.7.2/develocity-gradle-build-validation-2.7.2.zip && unzip -q -o develocity-gradle-build-validation-2.7.2.zip
+curl -s -L -O https://github.com/gradle/develocity-build-validation-scripts/releases/download/v2.7.2/develocity-gradle-build-validation-2.7.2.zip && unzip -q -o develocity-gradle-build-validation-2.7.2.zip
 ```
 
 ## Structure

--- a/Maven.md
+++ b/Maven.md
@@ -26,7 +26,7 @@ The build validation scripts are compatible with a large range of Maven versions
 Use the following command to download and unpack the build validation scripts for Maven to the current directory:
 
 ```bash
-curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v2.7.2/develocity-maven-build-validation-2.7.2.zip && unzip -q -o develocity-maven-build-validation-2.7.2.zip
+curl -s -L -O https://github.com/gradle/develocity-build-validation-scripts/releases/download/v2.7.2/develocity-maven-build-validation-2.7.2.zip && unzip -q -o develocity-maven-build-validation-2.7.2.zip
 ```
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Develocity Build Validation Scripts
 
-[![Verify Build](https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/workflows/build-verification.yml/badge.svg?branch=main)](https://github.com/gradle/gradle-enterprise-build-validation-scripts/actions/workflows/build-verification.yml)
+[![Verify Build](https://github.com/gradle/develocity-build-validation-scripts/actions/workflows/build-verification.yml/badge.svg?branch=main)](https://github.com/gradle/develocity-build-validation-scripts/actions/workflows/build-verification.yml)
 [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.solutions-team.gradle.com/scans)
 
 The purpose of the build validation scripts is to assist you in validating that your Gradle and Maven builds are in an optimal state in terms of maximizing work avoidance. The build validation scripts do not actually modify your build, but they surface what can be improved in your build to avoid unnecessary work in several scenarios.
@@ -43,7 +43,7 @@ Visit our website to learn more about [Develocity][develocity].
 The Develocity build validation scripts are open-source software released under the [Apache 2.0 License][apache-license].
 
 [develocity-build-config-samples]: https://github.com/gradle/develocity-build-config-samples
-[develocity-build-validation-scripts]: https://github.com/gradle/gradle-enterprise-build-validation-scripts
+[develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [ccud-gradle-plugin]: https://github.com/gradle/common-custom-user-data-gradle-plugin
 [ccud-maven-extension]: https://github.com/gradle/common-custom-user-data-maven-extension

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -376,7 +376,7 @@ val generateChecksums by tasks.registering(Checksum::class) {
 githubRelease {
     token((findProperty("github.access.token") ?: System.getenv("GITHUB_ACCESS_TOKEN") ?: "").toString())
     owner.set("gradle")
-    repo.set("gradle-enterprise-build-validation-scripts")
+    repo.set("develocity-build-validation-scripts")
     targetCommitish.set("main")
     releaseName.set(gitHubReleaseName())
     tagName.set(gitReleaseTag())

--- a/components/scripts/README.md
+++ b/components/scripts/README.md
@@ -2,7 +2,7 @@ Develocity Build Validation Scripts
 ==========================================
 
 Details and instructions on how to use the build validation scripts can be found here:
-https://github.com/gradle/gradle-enterprise-build-validation-scripts
+https://github.com/gradle/develocity-build-validation-scripts
 
 The Develocity Build Validation scripts are open-source software released under the Apache 2.0 License:
 https://www.apache.org/licenses/LICENSE-2.0.html

--- a/components/scripts/lib/interactive-mode.sh
+++ b/components/scripts/lib/interactive-mode.sh
@@ -45,7 +45,7 @@ during daily development, it is advisable that you apply the Common Custom User
 Data Gradle plugin to your build. Details on how to apply the plugin are
 available from the documentation of the build validation scripts.
 
-https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#applying-the-common-custom-user-data-gradle-plugin
+https://github.com/gradle/develocity-build-validation-scripts/blob/main/Gradle.md#applying-the-common-custom-user-data-gradle-plugin
 
 Your updated build configuration should be pushed before proceeding.
 
@@ -73,7 +73,7 @@ during daily development, it is advisable that you apply the Common Custom User
 Data Maven extension to your build. Details on how to apply the extension are
 available from the documentation of the build validation scripts.
 
-https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#applying-the-common-custom-user-data-maven-extension
+https://github.com/gradle/develocity-build-validation-scripts/blob/main/Maven.md#applying-the-common-custom-user-data-maven-extension
 
 Your updated build configuration should be pushed before proceeding.
 
@@ -239,9 +239,9 @@ explain_prerequisites_api_access() {
   fi
 
   if [[ "${BUILD_TOOL}" == "Maven" ]]; then
-    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md#authenticating-with-develocity"
+    documentation_link="https://github.com/gradle/develocity-build-validation-scripts/blob/main/Maven.md#authenticating-with-develocity"
   else
-    documentation_link="https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#authenticating-with-develocity"
+    documentation_link="https://github.com/gradle/develocity-build-validation-scripts/blob/main/Gradle.md#authenticating-with-develocity"
   fi
 
   IFS='' read -r -d '' text <<EOF


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts