### PR TITLE
Configure pre-releases as draft

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -381,6 +381,7 @@ githubRelease {
     releaseName.set(gitHubReleaseName())
     tagName.set(gitReleaseTag())
     prerelease.set(isDevelopmentRelease)
+    draft.set(isDevelopmentRelease)
     overwrite.set(isDevelopmentRelease)
     generateReleaseNotes.set(false)
     body.set(releaseNotes)


### PR DESCRIPTION
In attempt to prevent notification updates for every commit on CI.

Closes #780