### PR TITLE
Automatic development releases are removed

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -1,6 +1,10 @@
 name: Run Cross-Platform Tests (Build From Source)
 
-on: [ workflow_dispatch ]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -1,13 +1,15 @@
 name: Create Development Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Enter the confirmation phrase 'DEVELOPMENT' (without quotes) if you are sure you want to trigger a development release.
+        required: true
 
 jobs:
   development_release:
+    if: github.event.inputs.confirmation == 'DEVELOPMENT'
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Every GitHub release, including pre-releases, will notify any repository watchers. We were previously creating a new development release on every commit to `main`. This creates a lot of noise for anyone watching the repository. Many of these commits aren't meaningful enough to warrant creating a development release.

The reason we did this was so we could run the cross-version tests using the latest changes in main in the form of a distribution. We feel we've outgrown this need and are removing the automated development releases.

Instead, `main` will be tested by building from source and development releases will no longer be created on every commit. There will still be a way to create development releases manually for changes that are meaningful enough and need to be used before a proper release.

Closes #780 