### PR TITLE
Unsuccessful exit code returned when performance characteristics are unknown and `--fail-if-not-fully-cacheable` is used

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -86,13 +86,14 @@ is invoked, as shown in the example below.
 
 The scripts return with an exit code that depends on the outcome of running a given experiment.
 
-| Exit Code | Reason                                                                                                 |
-|-----------|--------------------------------------------------------------------------------------------------------|
-| 0         | The experiment completed successfully                                                                  |
-| 1         | An invalid input was provided while attempting to run the experiment                                   |
-| 2         | One of the builds that is part of the experiment failed                                                |
-| 3         | The build was not fully cacheable for the given task graph and `--fail-if-not-fully-cacheable` was set |
-| 100       | An unclassified, fatal error happened while running the experiment                                     |
+| Exit Code | Reason                                                                                                                         |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------|
+| 0         | The experiment completed successfully                                                                                          |
+| 1         | An invalid input was provided while attempting to run the experiment                                                           |
+| 2         | One of the builds that is part of the experiment failed                                                                        |
+| 3         | Option `--fail-if-not-fully-cacheable` was set and the build was not fully cacheable for the given task graph                  |
+| 4         | Option `--fail-if-not-fully-cacheable` was set and performance characteristics are unknown, e.g., due to a failed API response |
+| 100       | An unclassified, fatal error happened while running the experiment                                                             |
 
 ## Verifying the setup
 

--- a/Maven.md
+++ b/Maven.md
@@ -84,13 +84,14 @@ is invoked, as shown in the example below.
 
 The scripts return with an exit code that depends on the outcome of running a given experiment.
 
-| Exit Code | Reason                                                                                                     |
-|-----------|------------------------------------------------------------------------------------------------------------|
-| 0         | The experiment completed successfully                                                                      |
-| 1         | An invalid input was provided while attempting to run the experiment                                       |
-| 2         | One of the builds that is part of the experiment failed                                                    |
-| 3         | The build was not fully cacheable for the given execution plan and `--fail-if-not-fully-cacheable` was set |
-| 100       | An unclassified, fatal error happened while running the experiment                                         |
+| Exit Code | Reason                                                                                                                         |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------|
+| 0         | The experiment completed successfully                                                                                          |
+| 1         | An invalid input was provided while attempting to run the experiment                                                           |
+| 2         | One of the builds that is part of the experiment failed                                                                        |
+| 3         | Option `--fail-if-not-fully-cacheable` was set and the build was not fully cacheable for the given execution plan              |
+| 4         | Option `--fail-if-not-fully-cacheable` was set and performance characteristics are unknown, e.g., due to a failed API response |
+| 100       | An unclassified, fatal error happened while running the experiment                                                             |
 
 ## Verifying the setup
 

--- a/components/scripts/lib/exit-code.sh
+++ b/components/scripts/lib/exit-code.sh
@@ -4,9 +4,10 @@ SUCCESS=0
 INVALID_INPUT=1
 BUILD_FAILED=2
 BUILD_NOT_FULLY_CACHEABLE=3
+PERFORMANCE_CHARACTERISTICS_UNKNOWN=4
 UNEXPECTED_ERROR=100
 
-readonly SUCCESS INVALID_INPUT UNEXPECTED_ERROR BUILD_FAILED BUILD_NOT_FULLY_CACHEABLE
+readonly SUCCESS INVALID_INPUT UNEXPECTED_ERROR BUILD_FAILED BUILD_NOT_FULLY_CACHEABLE PERFORMANCE_CHARACTERISTICS_UNKNOWN
 
 # Overrides the die() function loaded from the argbash-generated parsing libs
 die() {
@@ -25,11 +26,20 @@ exit_with_return_code() {
   fi
 
   if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    if [[ -z "${executed_cacheable_num_tasks[1]}" ]]; then
+      print_bl
+      die "FAILURE: Unable to determine if build is fully cacheable: Performance characteristics are unknown and --fail-if-not-fully-cacheable was used." "${PERFORMANCE_CHARACTERISTICS_UNKNOWN}"
+    fi
+
     local executed_avoidable_tasks
     executed_avoidable_tasks=$(( executed_cacheable_num_tasks[1] ))
     if (( executed_avoidable_tasks > 0 )); then
       print_bl
-      die "FAILURE: Build is not fully cacheable for the given task graph." "${BUILD_NOT_FULLY_CACHEABLE}"
+      if [[ "${BUILD_TOOL}" == "Maven" ]]; then
+        die "FAILURE: Build is not fully cacheable for the given execution plan." "${BUILD_NOT_FULLY_CACHEABLE}"
+      else
+        die "FAILURE: Build is not fully cacheable for the given task graph." "${BUILD_NOT_FULLY_CACHEABLE}"
+      fi
     fi
   fi
   exit "${SUCCESS}"

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
-- [NEW] TBD
+- [FIX] Successful exit code returned when performance characteristics are unknown and `--fail-if-not-fully-cacheable` is used


### PR DESCRIPTION
When using the `--fail-if-not-fully-cacheable` option, the scripts will return with exit code `3` if the number of cacheable tasks/goals is > 0. The main use case for this feature is to fail a recurring CI build when build logic is introduced that causes build cache misses.

Previously, if `--fail-if-not-fully-cacheable` was used the Develocity API call to retrieve cacheability data failed, e.g., the default 10 second build ingest wait timeout was exceeded, the scripts would return with exit code `0` (successful). This is problematic because it's actually unknown whether or not the build is fully cacheable.

With these changes, if the number of executed cacheable tasks/goals is unknown for any reason and `--fail-if-not-fully-cacheable` is used, the scripts will return with exit code `4` (unsuccessful).

The new behavior can be seen in this screenshot.

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/7fd6196a-ffe8-40cd-9dcb-2984298a3c90" />

Closes #493 