### PR TITLE
Scripts wait longer for builds to ingest when `--fail-if-not-fully-cacheable` is used

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ val isDevelopmentRelease = !hasProperty("finalRelease")
 val releaseVersion = releaseVersion()
 val releaseNotes = releaseNotes()
 val distributionVersion = distributionVersion()
-val buildScanSummaryVersion = "1.0.1-2024.1"
+val buildScanSummaryVersion = "1.0.2-2024.1"
 
 allprojects {
     version = releaseVersion.get()

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -95,6 +95,10 @@ fetch_build_scan_data() {
     args+=("--brief-logging")
   fi
 
+  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+    args+=("--build-scan-availability-wait-timeout" "60")
+  fi
+
   for run_num in "${!build_scan_urls[@]}"; do
     args+=( "${run_num},${build_scan_urls[run_num]}" )
   done

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,6 +1,7 @@
 > [!IMPORTANT]
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
+- [FIX] Scripts do not wait long enough for build scans to become available when `--fail-if-not-fully-cacheable` is used
 - [FIX] Successful exit code returned when performance characteristics are unknown and `--fail-if-not-fully-cacheable` is used
 - [FIX] Gradle experiments do not disable background Build Scan publication
 - [FIX] Common Custom User Data Gradle plugin not injected for Gradle builds


### PR DESCRIPTION
This change adds the `--availability-wait-timeout` option to the build scan summary tool invocation with a value of '60' when the `--fail-if-not-fully-cacheable` option is used.

This should increase the likelihood of experiment build scans being ingested in order to retrieve the required data from the Develocity API to determine cacheability.

The `availabilityWaitTimeoutSecs` query parameter is included on the Develocity API calls when the `--fail-if-not-fully-cacheable` option is included in the script invocation. 
![image](https://github.com/user-attachments/assets/de180c18-71d0-480c-9073-3447a4c197a3)

When the `--fail-if-not-fully-cacheable` option isn't included, no `availabilityWaitTimeoutSecs` parameter is included in the Develocity API call.
![image](https://github.com/user-attachments/assets/89ad22e4-7eab-41c6-8842-785b3fdcc9f0)

Closes #505 