### PR TITLE
Exception is written to `exceptions.txt` file on build scan error

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -54,6 +54,8 @@ def registerBuildScanActions = { def buildScan, def rootProjectName ->
     buildScan.onError { error ->
         def errorFile = new File(expDir, 'errors.txt')
         errorFile.text = 'Build Scan publishing failed.'
+        def exceptionFile = new File(expDir, 'exceptions.txt')
+        exceptionFile.text = error
     }
 }
 


### PR DESCRIPTION
This change adds a new file `exceptions.txt` that writes the contents of the `error` payload to a file. 