### PR TITLE
Background Build Scan publication is always disabled for Gradle

### DIFF
--- a/components/scripts/lib/gradle.sh
+++ b/components/scripts/lib/gradle.sh
@@ -41,6 +41,7 @@ invoke_gradle() {
     -Ddevelocity.build-validation.runId="${RUN_ID}"
     -Ddevelocity.build-validation.runNum="${run_num}"
     -Ddevelocity.build-validation.scriptsVersion="${SCRIPT_VERSION}"
+    -Ddevelocity.build-scan.upload-in-background=false
     -Ddevelocity.capture-file-fingerprints=true
     -Dpts.enabled=false
   )

--- a/release/changes.md
+++ b/release/changes.md
@@ -2,3 +2,4 @@
 > The distributions of the Develocity Build Validation Scripts prefixed with `gradle-enterprise` are deprecated and will be removed in a future release. Migrate to the distributions prefixed with `develocity` instead.
 
 - [FIX] Successful exit code returned when performance characteristics are unknown and `--fail-if-not-fully-cacheable` is used
+- [FIX] Gradle experiments do not disable background Build Scan publication


### PR DESCRIPTION
This was already the case for Maven.

https://github.com/gradle/develocity-build-validation-scripts/blob/12631715a9e1c045be0689b99f62a1e2d729f7f8/components/configure-develocity-maven-extension/src/main/java/com/gradle/ConfigureDevelocityAdaptor.java#L89-L93

![image](https://github.com/user-attachments/assets/1b8b3df9-349d-4d6f-b452-1fbe9eeda02d)

https://ge.solutions-team.gradle.com/s/uy2vxghmxko6e#switches