### PR TITLE
Build Scan publishing is enforced for the Develocity Gradle plugin

### DIFF
--- a/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
+++ b/components/scripts/gradle/gradle-init-scripts/configure-build-validation.gradle
@@ -128,6 +128,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')
                 }
 
+                develocity.buildScan.publishing.onlyIf { true }
                 registerBuildScanActions(develocity.buildScan, rootProject.name)
                 addBuildScanCustomData(develocity.buildScan, develocity.server.get())
             }
@@ -161,6 +162,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 failMissingDevelocityServerURL('https://docs.gradle.com/develocity/gradle-plugin/current/#connecting_to_develocity')
             }
 
+            settings.develocity.buildScan.publishing.onlyIf { true }
             registerBuildScanActions(settings.develocity.buildScan, settings.rootProject.name)
             addBuildScanCustomData(settings.develocity.buildScan, settings.develocity.server.get())
         }

--- a/release/changes.md
+++ b/release/changes.md
@@ -5,3 +5,4 @@
 - [FIX] Successful exit code returned when performance characteristics are unknown and `--fail-if-not-fully-cacheable` is used
 - [FIX] Gradle experiments do not disable background Build Scan publication
 - [FIX] Common Custom User Data Gradle plugin not injected for Gradle builds
+- [FIX] Build Scan publishing is not enforced for the Develocity Gradle plugin


### PR DESCRIPTION
When running the scripts, we need to ensure a build scan is always published despite what the user has configured in their build.

This was previously already the case for the Build Scan and Gradle Enterprise plugins. 