### PR TITLE
Expose GitHub summary unconditionally

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -122,12 +122,6 @@ runs:
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         
-        # Copy receipt to a predictable location
-        RECEIPT_FILE=".data/01-validate-incremental-building/latest/exp1-*.receipt"
-        if [ -f ${RECEIPT_FILE} ]; then
-          cp ${RECEIPT_FILE} ../receipt.txt
-        fi
-
         exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
@@ -136,12 +130,13 @@ runs:
       if: always()
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: receipt.txt
+        path: develocity-gradle-build-validation/.data/01-validate-incremental-building/latest/exp1-*.receipt
     - name: Fill GitHub summary
       if: always()
       run: |
-        if [ -f "receipt.txt" ]; then
-          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+        RECEIPT_FILE="develocity-gradle-build-validation/.data/01-validate-incremental-building/latest/exp1-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -115,7 +115,7 @@ runs:
           ${RUNNER_DEBUG:+"--debug"}
         EXPERIMENT_EXIT_CODE=$?
 
-        # Set step outputs
+        # Set the Build Scan urls as outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
         

--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -98,6 +98,9 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
+        # Do not exit on error to allow post-actions
+        set +e
+
         # Run the experiment
         ./01-validate-incremental-building.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -110,25 +113,36 @@ runs:
           ${ARG_DEVELOCITY_URL:+"-s" "$ARG_DEVELOCITY_URL"} \
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${RUNNER_DEBUG:+"--debug"}
+        EXPERIMENT_EXIT_CODE=$?
 
-        # Set the Build Scan urls as outputs
-        RECEIPT_FILE=".data/01-validate-incremental-building/latest/exp1-*.receipt"
+        # Set step outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         
-        cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
+        # Copy receipt to a predictable location
+        RECEIPT_FILE=".data/01-validate-incremental-building/latest/exp1-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cp ${RECEIPT_FILE} ../receipt.txt
+        fi
+
+        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: develocity-gradle-build-validation/.data/01-validate-incremental-building/latest*/exp1-*.receipt
-    - name: Add artifact link to summary
+        path: receipt.txt
+    - name: Fill GitHub summary
+      if: always()
       run: |
-        echo "-------------" >> $GITHUB_STEP_SUMMARY
-        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        if [ -f "receipt.txt" ]; then
+          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+          echo "-------------" >> $GITHUB_STEP_SUMMARY
+          echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -105,6 +105,9 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
+        # Do not exit on error to allow post-actions
+        set +e
+
         # Run the experiment
         ./02-validate-local-build-caching-same-location.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -118,25 +121,36 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
+        EXPERIMENT_EXIT_CODE=$?
 
         # Set the Build Scan urls as outputs
-        RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         
-        cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
+        # Copy receipt to a predictable location
+        RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cp ${RECEIPT_FILE} ../receipt.txt
+        fi
+
+        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: develocity-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest*/exp2-*.receipt
-    - name: Add artifact link to summary
+        path: receipt.txt
+    - name: Fill GitHub summary
+      if: always()
       run: |
-        echo "-------------" >> $GITHUB_STEP_SUMMARY
-        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        if [ -f "receipt.txt" ]; then
+          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+          echo "-------------" >> $GITHUB_STEP_SUMMARY
+          echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -130,12 +130,6 @@ runs:
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         
-        # Copy receipt to a predictable location
-        RECEIPT_FILE=".data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"
-        if [ -f ${RECEIPT_FILE} ]; then
-          cp ${RECEIPT_FILE} ../receipt.txt
-        fi
-
         exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
@@ -144,12 +138,13 @@ runs:
       if: always()
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: receipt.txt
+        path: develocity-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt
     - name: Fill GitHub summary
       if: always()
       run: |
-        if [ -f "receipt.txt" ]; then
-          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+        RECEIPT_FILE="develocity-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -129,12 +129,6 @@ runs:
         
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-        
-        # Copy receipt to a predictable location
-        RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"
-        if [ -f ${RECEIPT_FILE} ]; then
-          cp ${RECEIPT_FILE} ../receipt.txt
-        fi
 
         exit $EXPERIMENT_EXIT_CODE
       shell: bash
@@ -144,12 +138,13 @@ runs:
       if: always()
       with:
         name: experiment-3-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: receipt.txt
+        path: develocity-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt
     - name: Fill GitHub summary
       if: always()
       run: |
-        if [ -f "receipt.txt" ]; then
-          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+        RECEIPT_FILE="develocity-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -105,6 +105,9 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
+        # Do not exit on error to allow post-actions
+        set +e
+
         # Run the experiment
         ./03-validate-local-build-caching-different-locations.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -118,25 +121,36 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
+        EXPERIMENT_EXIT_CODE=$?
 
         # Set the Build Scan urls as outputs
-        RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
         
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
+        
+        # Copy receipt to a predictable location
+        RECEIPT_FILE=".data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cp ${RECEIPT_FILE} ../receipt.txt
+        fi
 
-        cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
+        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: experiment-3-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: develocity-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest*/exp3-*.receipt
-    - name: Add artifact link to summary
+        path: receipt.txt
+    - name: Fill GitHub summary
+      if: always()
       run: |
-        echo "-------------" >> $GITHUB_STEP_SUMMARY
-        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        if [ -f "receipt.txt" ]; then
+          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+          echo "-------------" >> $GITHUB_STEP_SUMMARY
+          echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -105,6 +105,9 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-maven-build-validation
 
+        # Do not exit on error to allow post-actions
+        set +e
+        
         # Run the experiment
         ./01-validate-local-build-caching-same-location.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -118,25 +121,36 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
+        EXPERIMENT_EXIT_CODE=$?
 
-        # Set the Build Scan urls as outputs
-        RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"
+        # Set step outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
       
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
 
-        cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
+        # Copy receipt to a predictable location
+        RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cp ${RECEIPT_FILE} ../receipt.txt
+        fi
+
+        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: develocity-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest*/exp1-*.receipt
-    - name: Add artifact link to summary
+        path: receipt.txt
+    - name: Fill GitHub summary
+      if: always()
       run: |
-        echo "-------------" >> $GITHUB_STEP_SUMMARY
-        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        if [ -f "receipt.txt" ]; then
+          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+          echo "-------------" >> $GITHUB_STEP_SUMMARY
+          echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -130,12 +130,6 @@ runs:
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
 
-        # Copy receipt to a predictable location
-        RECEIPT_FILE=".data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"
-        if [ -f ${RECEIPT_FILE} ]; then
-          cp ${RECEIPT_FILE} ../receipt.txt
-        fi
-
         exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
@@ -144,12 +138,13 @@ runs:
       if: always()
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: receipt.txt
+        path: develocity-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt
     - name: Fill GitHub summary
       if: always()
       run: |
-        if [ -f "receipt.txt" ]; then
-          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+        RECEIPT_FILE="develocity-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -123,7 +123,7 @@ runs:
           ${RUNNER_DEBUG:+"--debug"}
         EXPERIMENT_EXIT_CODE=$?
 
-        # Set step outputs
+        # Set the Build Scan urls as outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
       

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -105,6 +105,9 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-maven-build-validation
 
+        # Do not exit on error to allow post-actions
+        set +e
+
         # Run the experiment
         ./02-validate-local-build-caching-different-locations.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -118,25 +121,36 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
+        EXPERIMENT_EXIT_CODE=$?
 
-        # Set the Build Scan urls as outputs
-        RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"
+        # Set step outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
        
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
 
-        cat $RECEIPT_FILE >> $GITHUB_STEP_SUMMARY
+        # Copy receipt to a predictable location
+        RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cp ${RECEIPT_FILE} ../receipt.txt
+        fi
+
+        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: develocity-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest*/exp2-*.receipt
-    - name: Add artifact link to summary
+        path: receipt.txt
+    - name: Fill GitHub summary
+      if: always()
       run: |
-        echo "-------------" >> $GITHUB_STEP_SUMMARY
-        echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        if [ -f "receipt.txt" ]; then
+          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+          echo "-------------" >> $GITHUB_STEP_SUMMARY
+          echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        fi
       shell: bash

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -130,12 +130,6 @@ runs:
         echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
         echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
 
-        # Copy receipt to a predictable location
-        RECEIPT_FILE=".data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"
-        if [ -f ${RECEIPT_FILE} ]; then
-          cp ${RECEIPT_FILE} ../receipt.txt
-        fi
-
         exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
@@ -144,12 +138,13 @@ runs:
       if: always()
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
-        path: receipt.txt
+        path: develocity-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt
     - name: Fill GitHub summary
       if: always()
       run: |
-        if [ -f "receipt.txt" ]; then
-          cat receipt.txt >> $GITHUB_STEP_SUMMARY
+        RECEIPT_FILE="develocity-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"
+        if [ -f ${RECEIPT_FILE} ]; then
+          cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -123,7 +123,7 @@ runs:
           ${RUNNER_DEBUG:+"--debug"}
         EXPERIMENT_EXIT_CODE=$?
 
-        # Set step outputs
+        # Set the Build Scan urls as outputs
         BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
         BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
        


### PR DESCRIPTION
### Issue
The GitHub summary is not published when the validation scripts run as part of the [GiHub composite actions](https://github.com/gradle/develocity-build-validation-scripts/tree/main/.github/actions) fail.

### Fix 
The validation scripts are run within a bash step which is by default configured to exit immediately upon command failure
```
set -e
```
The fix is to revert this configuration and capture the validation script exit code to allow post actions within the step (build scan links capture and receipt file renaming)
Subsequent steps to archive the receipt and inline it in the summary are configured to run unconditionnally
```
if: always()
```

### Implementation details
- The receipt file is renamed to  a predictable receipt.txt file to avoid passing the filename across steps and adding an attack surface as the file content is archived and inlined in the GitHub summary
- the `upload-artifact` step is using the default configuration which triggers a warning message when the receipt file is not present. This is an interesting information for the action consumer.