### PR TITLE
Move build scan link captures in GitHub summary step

### DIFF
--- a/.github/actions/gradle/experiment-1/action.yml
+++ b/.github/actions/gradle/experiment-1/action.yml
@@ -40,16 +40,15 @@ inputs:
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
-    value: ${{ steps.run.outputs.buildScanFirstBuild }}
+    value: ${{ steps.summary.outputs.buildScanFirstBuild }}
   buildScanSecondBuild:
     description: "Second build scan url"
-    value: ${{ steps.run.outputs.buildScanSecondBuild }}
+    value: ${{ steps.summary.outputs.buildScanSecondBuild }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Gradle Experiment 1
-      id: run
       run: |
         # Read the action inputs
         ARG_GIT_REPO=""
@@ -98,9 +97,6 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
-        # Do not exit on error to allow post-actions
-        set +e
-
         # Run the experiment
         ./01-validate-incremental-building.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -113,16 +109,6 @@ runs:
           ${ARG_DEVELOCITY_URL:+"-s" "$ARG_DEVELOCITY_URL"} \
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${RUNNER_DEBUG:+"--debug"}
-        EXPERIMENT_EXIT_CODE=$?
-
-        # Set the Build Scan urls as outputs
-        BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
-        BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
-        
-        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
-        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-        
-        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
@@ -131,7 +117,8 @@ runs:
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: develocity-gradle-build-validation/.data/01-validate-incremental-building/latest/exp1-*.receipt
-    - name: Fill GitHub summary
+    - name: Fill GitHub summary and outputs
+      id: summary
       if: always()
       run: |
         RECEIPT_FILE="develocity-gradle-build-validation/.data/01-validate-incremental-building/latest/exp1-*.receipt"
@@ -139,5 +126,12 @@ runs:
           cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set the Build Scan urls as outputs
+          BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+
+          echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+          echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/actions/gradle/experiment-2/action.yml
+++ b/.github/actions/gradle/experiment-2/action.yml
@@ -43,16 +43,15 @@ inputs:
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
-    value: ${{ steps.run.outputs.buildScanFirstBuild }}
+    value: ${{ steps.summary.outputs.buildScanFirstBuild }}
   buildScanSecondBuild:
     description: "Second build scan url"
-    value: ${{ steps.run.outputs.buildScanSecondBuild }}
+    value: ${{ steps.summary.outputs.buildScanSecondBuild }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Gradle Experiment 2
-      id: run
       run: |
         # Read the action inputs
         ARG_GIT_REPO=""
@@ -105,9 +104,6 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
-        # Do not exit on error to allow post-actions
-        set +e
-
         # Run the experiment
         ./02-validate-local-build-caching-same-location.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -121,16 +117,6 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
-        EXPERIMENT_EXIT_CODE=$?
-
-        # Set the Build Scan urls as outputs
-        BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
-        BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
-        
-        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
-        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-        
-        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
@@ -139,7 +125,8 @@ runs:
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: develocity-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt
-    - name: Fill GitHub summary
+    - name: Fill GitHub summary and outputs
+      id: summary
       if: always()
       run: |
         RECEIPT_FILE="develocity-gradle-build-validation/.data/02-validate-local-build-caching-same-location/latest/exp2-*.receipt"
@@ -147,5 +134,12 @@ runs:
           cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set the Build Scan urls as outputs
+          BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          
+          echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+          echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/actions/gradle/experiment-3/action.yml
+++ b/.github/actions/gradle/experiment-3/action.yml
@@ -43,16 +43,15 @@ inputs:
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
-    value: ${{ steps.run.outputs.buildScanFirstBuild }}
+    value: ${{ steps.summary.outputs.buildScanFirstBuild }}
   buildScanSecondBuild:
     description: "Second build scan url"
-    value: ${{ steps.run.outputs.buildScanSecondBuild }}
+    value: ${{ steps.summary.outputs.buildScanSecondBuild }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Gradle Experiment 3
-      id: run
       run: |
         # Read the action inputs
         ARG_GIT_REPO=""
@@ -105,9 +104,6 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-gradle-build-validation
 
-        # Do not exit on error to allow post-actions
-        set +e
-
         # Run the experiment
         ./03-validate-local-build-caching-different-locations.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -121,16 +117,6 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
-        EXPERIMENT_EXIT_CODE=$?
-
-        # Set the Build Scan urls as outputs
-        BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
-        BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
-        
-        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
-        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-
-        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
@@ -139,7 +125,8 @@ runs:
       with:
         name: experiment-3-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: develocity-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt
-    - name: Fill GitHub summary
+    - name: Fill GitHub summary and outputs
+      id: summary
       if: always()
       run: |
         RECEIPT_FILE="develocity-gradle-build-validation/.data/03-validate-local-build-caching-different-locations/latest/exp3-*.receipt"
@@ -147,5 +134,12 @@ runs:
           cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set the Build Scan urls as outputs
+          BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+
+          echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+          echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/actions/maven/experiment-1/action.yml
+++ b/.github/actions/maven/experiment-1/action.yml
@@ -43,16 +43,15 @@ inputs:
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
-    value: ${{ steps.run.outputs.buildScanFirstBuild }}
+    value: ${{ steps.summary.outputs.buildScanFirstBuild }}
   buildScanSecondBuild:
     description: "Second build scan url"
-    value: ${{ steps.run.outputs.buildScanSecondBuild }}
+    value: ${{ steps.summary.outputs.buildScanSecondBuild }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Maven Experiment 1
-      id: run
       run: |
         # Read the action inputs
         ARG_GIT_REPO=""
@@ -105,9 +104,6 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-maven-build-validation
 
-        # Do not exit on error to allow post-actions
-        set +e
-        
         # Run the experiment
         ./01-validate-local-build-caching-same-location.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -121,16 +117,6 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
-        EXPERIMENT_EXIT_CODE=$?
-
-        # Set the Build Scan urls as outputs
-        BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
-        BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
-      
-        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
-        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-
-        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
@@ -139,7 +125,8 @@ runs:
       with:
         name: experiment-1-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: develocity-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt
-    - name: Fill GitHub summary
+    - name: Fill GitHub summary and outputs
+      id: summary
       if: always()
       run: |
         RECEIPT_FILE="develocity-maven-build-validation/.data/01-validate-local-build-caching-same-location/latest/exp1-*.receipt"
@@ -147,5 +134,12 @@ runs:
           cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set the Build Scan urls as outputs
+          BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          
+          echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+          echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         fi
       shell: bash

--- a/.github/actions/maven/experiment-2/action.yml
+++ b/.github/actions/maven/experiment-2/action.yml
@@ -43,16 +43,15 @@ inputs:
 outputs:
   buildScanFirstBuild:
     description: "First build scan url"
-    value: ${{ steps.run.outputs.buildScanFirstBuild }}
+    value: ${{ steps.summary.outputs.buildScanFirstBuild }}
   buildScanSecondBuild:
     description: "Second build scan url"
-    value: ${{ steps.run.outputs.buildScanSecondBuild }}
+    value: ${{ steps.summary.outputs.buildScanSecondBuild }}
 
 runs:
   using: "composite"
   steps:
     - name: Run Maven Experiment 2
-      id: run
       run: |
         # Read the action inputs
         ARG_GIT_REPO=""
@@ -105,9 +104,6 @@ runs:
         # Navigate into the folder containing the validation scripts
         cd develocity-maven-build-validation
 
-        # Do not exit on error to allow post-actions
-        set +e
-
         # Run the experiment
         ./02-validate-local-build-caching-different-locations.sh \
           ${ARG_GIT_REPO:+"-r" "$ARG_GIT_REPO"} \
@@ -121,16 +117,6 @@ runs:
           ${ARG_DEVELOCITY_ENABLE:+"-e"} \
           ${ARG_FAIL_IF_NOT_FULLY_CACHEABLE:+"-f"} \
           ${RUNNER_DEBUG:+"--debug"}
-        EXPERIMENT_EXIT_CODE=$?
-
-        # Set the Build Scan urls as outputs
-        BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | sed 's/.* //')
-        BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | sed 's/.* //')
-       
-        echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
-        echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
-
-        exit $EXPERIMENT_EXIT_CODE
       shell: bash
     - name: Archive receipt
       id: upload-artifact
@@ -139,7 +125,8 @@ runs:
       with:
         name: experiment-2-receipt-${{ github.job }}${{ strategy.job-total > 1 && format('-{0}', strategy.job-index) || '' }}
         path: develocity-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt
-    - name: Fill GitHub summary
+    - name: Fill GitHub summary and outputs
+      id: summary
       if: always()
       run: |
         RECEIPT_FILE="develocity-maven-build-validation/.data/02-validate-local-build-caching-different-locations/latest/exp2-*.receipt"
@@ -147,5 +134,12 @@ runs:
           cat ${RECEIPT_FILE} >> $GITHUB_STEP_SUMMARY
           echo "-------------" >> $GITHUB_STEP_SUMMARY
           echo "Download receipt: ${{ steps.upload-artifact.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set the Build Scan urls as outputs
+          BUILD_SCAN_1=$(grep -m 1 "first build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          BUILD_SCAN_2=$(grep -m 1 "second build" ${RECEIPT_FILE} | grep -o 'http.\S\+')
+          
+          echo "buildScanFirstBuild=$BUILD_SCAN_1" >> $GITHUB_OUTPUT
+          echo "buildScanSecondBuild=$BUILD_SCAN_2" >> $GITHUB_OUTPUT
         fi
       shell: bash


### PR DESCRIPTION
This PR fixes the composite actions outputs using unpopulated `RECEIPT_FILE` by moving the build scan link captures to the GitHub summary step.
This also allows to remove `set +e` as no script post-action is required anymore.

Additionally, the regular expression to capture build scan links has been fixed to capture correctly failed build scan links suffixed with `FAILED`