### PR TITLE
Updated GithubActions to use JDK 17

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
Updated GithubActions to use JDK 17. This is a required change, required by the [org.gradle.toolchains.foojay-resolver-convention](https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention) plugin v1.0.0. 

Without this, we either can't upgrade to the latest version of [org.gradle.toolchains.foojay-resolver-convention](https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention), or we have failing builds as seen on the [example resolver upgrade PR](https://github.com/gradle/develocity-build-validation-scripts/pull/832).