### PR TITLE
Update from `windows-2019` to `windows-2025`

### DIFF
--- a/.github/workflows/cross-platform-testing-build-from-source.yml
+++ b/.github/workflows/cross-platform-testing-build-from-source.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu-24.04
           - macos-13 # x86_64
           - macos-14 # aarch64
-          - windows-2019
+          - windows-2025
         # Only LTS versions greater than 8 are tested
         java-version: [ '8', '11', '17', '21' ]
         include:
@@ -55,7 +55,7 @@ jobs:
             shell: bash
           - os: macos-14
             shell: bash
-          - os: windows-2019
+          - os: windows-2025
             shell: wsl-bash
     defaults:
       run:

--- a/.github/workflows/cross-platform-testing-use-development-release.yml
+++ b/.github/workflows/cross-platform-testing-use-development-release.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-24.04
           - macos-13 # x86_64
           - macos-14 # aarch64
-          - windows-2019
+          - windows-2025
         # Only LTS versions greater than 8 are tested
         java-version: [ '8', '11', '17', '21' ]
         include:
@@ -30,7 +30,7 @@ jobs:
             shell: bash
           - os: macos-14
             shell: bash
-          - os: windows-2019
+          - os: windows-2025
             shell: wsl-bash
     defaults:
       run:


### PR DESCRIPTION
This PR updates the Windows version used from 2019 to 2025 as version 2019 will soon be removed.