### PR TITLE
Make max wait time for Build Scan data configurable

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -168,7 +168,7 @@ If your Develocity server is using a certificate signed by an internal Certifica
 
 In the unlikely and insecure case that your Develocity server is using a self-signed certificate, edit the `network.settings` file and uncomment and update the lines that start with `ssl`.
 
-If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`.
+If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`. If the build scan data is not yet available when fetched, edit the `network.settings` file and uncomment and update the `max.wait.time` line.
 
 ## Configuring custom value lookup names
 

--- a/Maven.md
+++ b/Maven.md
@@ -166,7 +166,7 @@ If your Develocity server is using a certificate signed by an internal Certifica
 
 In the unlikely and insecure case that your Develocity server is using a self-signed certificate, edit the `network.settings` file and uncomment and update the lines that start with `ssl`.
 
-If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`.
+If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`. If the build scan data is not yet available when fetched, edit the `network.settings` file and uncomment and update the `max.wait.time` line.
 
 ## Configuring custom value lookup names
 

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -4,6 +4,34 @@ readonly LOGGING_BRIEF='brief_logging'
 readonly LOGGING_VERBOSE='verbose_logging'
 readonly RUN_ID_NONE=''
 
+read_network_setting() {
+  local key="$1"
+  local settings_file="${SCRIPT_DIR}/network.settings"
+  if [ -f "${settings_file}" ]; then
+    local value
+    value=$(grep -E "^${key}=" "${settings_file}" | head -1 | cut -d'=' -f2-)
+    if [ -n "${value}" ]; then
+      printf '%s' "${value}"
+    fi
+  fi
+}
+
+parse_duration_to_seconds() {
+  local duration="$1"
+  local total=0
+
+  if [[ "${duration}" =~ ^PT(([0-9]+)H)?(([0-9]+)M)?(([0-9]+)S)?$ ]]; then
+    local hours="${BASH_REMATCH[2]:-0}"
+    local minutes="${BASH_REMATCH[4]:-0}"
+    local seconds="${BASH_REMATCH[6]:-0}"
+    total=$(( hours * 3600 + minutes * 60 + seconds ))
+  else
+    die "ERROR: Invalid duration format '${duration}'. Expected ISO 8601 duration (e.g., PT2M, PT30S, PT1H30M)."
+  fi
+
+  printf '%d' "${total}"
+}
+
 # Main entrypoint for processing data online using the Build Scan summary tool.
 # All scripts should call this function to fetch Build Scan data used in the
 # experiment summary.
@@ -102,7 +130,12 @@ fetch_build_scan_data() {
     args+=("--brief-logging")
   fi
 
-  if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
+  local max_wait_time_setting
+  max_wait_time_setting="$(read_network_setting 'max.wait.time')"
+
+  if [ -n "${max_wait_time_setting}" ]; then
+    args+=("--max-total-wait-time" "$(parse_duration_to_seconds "${max_wait_time_setting}")")
+  elif [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
     args+=("--max-total-wait-time" "120")
   fi
 

--- a/components/scripts/network.settings
+++ b/components/scripts/network.settings
@@ -21,3 +21,6 @@
 # Uncomment to use a custom connect or read timeout when fetching Build Scan data
 #connect.timeout=PT5S
 #read.timeout=PT30S
+
+# Uncomment to use a custom max wait time for Build Scan data to become available
+#max.wait.time=PT2M


### PR DESCRIPTION
## Summary
- Adds `max.wait.time` setting to `network.settings` for configuring how long scripts wait for Build Scan data to become available (ISO 8601 duration, e.g., `PT2M`)
- Extracts `read_network_setting` and `parse_duration_to_seconds` helpers in `build-scan-online.sh`
- Falls back to existing 120s wait for `-f` runs when no custom value is configured; no wait for non-`-f` runs (preserving current behavior as default)

Supersedes #923 and #924.