### PR TITLE
Require Build Scans when failing on non-cacheable builds

### DIFF
--- a/Gradle.md
+++ b/Gradle.md
@@ -168,7 +168,7 @@ If your Develocity server is using a certificate signed by an internal Certifica
 
 In the unlikely and insecure case that your Develocity server is using a self-signed certificate, edit the `network.settings` file and uncomment and update the lines that start with `ssl`.
 
-If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`.
+If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`. If the build scan data is not yet available when fetched, edit the `network.settings` file and uncomment and update the `max.wait.time` line.
 
 ## Configuring custom value lookup names
 

--- a/Maven.md
+++ b/Maven.md
@@ -166,7 +166,7 @@ If your Develocity server is using a certificate signed by an internal Certifica
 
 In the unlikely and insecure case that your Develocity server is using a self-signed certificate, edit the `network.settings` file and uncomment and update the lines that start with `ssl`.
 
-If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`.
+If the requests to fetch the build scan data from your Develocity server are timing out, edit the `network.settings` file and uncomment and update the lines that end with `timeout`. If the build scan data is not yet available when fetched, edit the `network.settings` file and uncomment and update the `max.wait.time` line.
 
 ## Configuring custom value lookup names
 

--- a/components/scripts/lib/build-scan-online.sh
+++ b/components/scripts/lib/build-scan-online.sh
@@ -102,8 +102,11 @@ fetch_build_scan_data() {
     args+=("--brief-logging")
   fi
 
+  # When failing the build if it is not fully cacheable, the Build Scan data
+  # must be available, so instruct the summary tool to wait longer for it to
+  # become available. A user-set max.wait.time in network.settings always wins.
   if [[ "${fail_if_not_fully_cacheable}" == "on" ]]; then
-    args+=("--max-total-wait-time" "120")
+    args+=("--require-build-scans")
   fi
 
   if [[ -n "${run_id}" ]]; then

--- a/components/scripts/network.settings
+++ b/components/scripts/network.settings
@@ -21,3 +21,6 @@
 # Uncomment to use a custom connect or read timeout when fetching Build Scan data
 #connect.timeout=PT5S
 #read.timeout=PT30S
+
+# Uncomment to set the total time to wait for Build Scan data to become available on the Develocity server
+#max.wait.time=PT2M

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,1 @@
-- [NEW] TBD
 - [NEW] Add a `max.wait.time` setting to `network.settings` to configure how long to wait for Develocity Build Scan data to become available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,2 +1,2 @@
 - [NEW] TBD
-- [FIX] Wait longer for Build Scan data to become available when `--fail-if-not-fully-cacheable` is set, and allow the wait time to be configured via `max.wait.time` in `network.settings`
+- [NEW] Add a `max.wait.time` setting to `network.settings` to configure how long to wait for Develocity Build Scan data to become available

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,1 +1,2 @@
 - [NEW] TBD
+- [FIX] Wait longer for Build Scan data to become available when `--fail-if-not-fully-cacheable` is set, and allow the wait time to be configured via `max.wait.time` in `network.settings`


### PR DESCRIPTION
## Summary
When `--fail-if-not-fully-cacheable` is set, the Build Scan data must be available for the summary tool to determine cacheability. Previously the fetch could fail if the data was not yet ingested on the server.

- BVS passes a new `--require-build-scans` flag to `fetch-build-scan-data` **only** in the fully-cacheable/CI mode (i.e. when `--fail-if-not-fully-cacheable` is active). This tells the summary tool to use its long default wait for Build Scan data to become available; without it, the short default applies.
- The summary tool now owns the wait-time decision. BVS no longer parses `network.settings` or computes/passes a wait value.
- A new `max.wait.time` property (ISO 8601 duration, e.g. `PT2M`) can be set in `network.settings` to override the wait time; a user-set value always wins over the mode default.

This supersedes the earlier approach (BVS reading `network.settings` and passing `--max-total-wait-time`).

## Dependencies / blockers
- Depends on the build-scan-summary change in gradle/dv#63516, which adds the `--require-build-scans` flag and moves the wait-time decision into the summary tool. The flag string `--require-build-scans` must stay in sync between the two PRs.
- **Blocked on publishing:** after gradle/dv#63516 is merged, a build-scan-summary release must be published before this PR can be finalized. The `buildScanSummaryVersion` bump to that published version is a follow-up commit here — intentionally not included yet, since no definite version exists.

## Verified locally
Against a locally published build-scan-summary (`1.0.8-2026.1.0` in mavenLocal): distribution assembles, the bundled tool accepts `--require-build-scans` (and no longer exposes `--max-total-wait-time`), and BVS emits the flag only when `--fail-if-not-fully-cacheable` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)